### PR TITLE
Fix interface name.

### DIFF
--- a/game-api/sound-engine.md
+++ b/game-api/sound-engine.md
@@ -24,7 +24,7 @@ Game.audio().playSound(mySound, myEntity);
 Game.audio().playMusic(Resources.sounds().get("my-music.ogg"));
 
 // use the SoundPlayback to react to events
-ISoundPlayback playback = Game.audio().playSound(mySound);
+SoundPlayback playback = Game.audio().playSound(mySound);
 playback.addSoundPlaybackListener(new SoundPlaybackListener() {
 
   @Override


### PR DESCRIPTION
The name of the `SoundPlayback` is appearently `SoundPlayblack` and not the hungarian notation variant `ISoundPlayback`.

see interface `SoundPlayback`:
- https://github.com/gurkenlabs/litiengine/blob/main/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/SoundPlayback.java

and method `SoundEngine#playSound(Sound)`:
- https://github.com/gurkenlabs/litiengine/blob/e9fda2a5bbd3c294538245bfc013e8b17c27797b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/SoundEngine.java#L439-L448